### PR TITLE
Update Example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Create `.github/workflow/deploy.yaml` with the following to build on push.
 on:
   push:
     branches:
-      - "master" # change to the branch you wish to deploy from
+      - "main" # change to the branch you wish to deploy from
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Create `.github/workflow/deploy.yaml` with the following to build on push.
 on:
   push:
     branches:
-      - "main"
+      - "master" # change to the branch you wish to deploy from
 
 permissions:
   contents: read
@@ -39,7 +39,7 @@ jobs:
     - id: build-publish
       uses: bitovi/github-actions-react-to-ghp@v1.2.0
       with:
-        path: dist
+        path: build # change to your build folder
 
 ```
 


### PR DESCRIPTION
Proposing update of Example usage to match react build folder defaults and Github branch defaults.

As I have not worked with github action pages before, I did not know where to change in the example, to deploy my react app.

I've added comments by these two values to highlight they may need to be changed.

I found in react the default folder was build, and default branch to be master when creating a new git project.

This project works great, and really helped me setup GH pages fast! All the best