### PR TITLE
Correct workflow folder name in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The following inputs can be used as `step.with` keys
 
 ## Example usage
 
-Create `.github/workflow/deploy.yaml` with the following to build on push.
+Create `.github/workflows/deploy.yaml` with the following to build on push.
 
 ```yaml
 on:


### PR DESCRIPTION
Change details:

I found an error in the repository's documentation that could cause confusion for other new users who wish to use the GitHub action in this project. The issue is that the README.md file states that the folder for workflows should be named as .github/workflow, when in fact, it should be named as .github/workflows with an "s" at the end.

I have updated the README.md file with the correction so that other new users do not have similar issues in the future.

Contribution:

I forked the repository and made the correction on a new branch named fix/workflow-folder-name. I made a commit with the changes and created this pull request so that the project maintainers can review the changes and accept them if appropriate.

I would appreciate it if you could review and accept these changes as I hope it can help other new users in the future.